### PR TITLE
Add responsive layout and image to Cell2 component

### DIFF
--- a/src/components/box3/cellContent/Cell2.tsx
+++ b/src/components/box3/cellContent/Cell2.tsx
@@ -1,4 +1,22 @@
 import styled from 'styled-components'
+import WsImage from './WsImage'
+
+const InfoContainer = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  width: 100%;
+
+  @media (max-width: 550px) {
+    grid-template-columns: 1fr;
+    grid-template-rows: 1fr 1fr;
+  }
+
+  @media (max-width: 320px) {
+    grid-template-columns: 1fr;
+    grid-template-rows: 1fr;
+  }
+`
 
 const StyledInfo = styled.div`
   margin-bottom: 1rem;
@@ -27,15 +45,18 @@ const InfoItem: React.FC<InfoItemProps> = ({ label, value }) => (
 )
 
 const Cell2 = () => (
-  <div>
-    <InfoItem label="First Name:" value="Warrick" />
-    <InfoItem label="Last Name:" value="Smith" />
-    <InfoItem label="Nationality:" value="New Zealand" />
-    <InfoItem label="Employment Status:" value="Available" />
-    <InfoItem label="Phone:" value="+64 21 0248 8139" />
-    <InfoItem label="Address:" value="Auckland, New Zealand" />
-    <InfoItem label="Spoken Languages:" value="English" />
-  </div>
+  <InfoContainer>
+    <div>
+      <InfoItem label="First Name:" value="Warrick" />
+      <InfoItem label="Last Name:" value="Smith" />
+      <InfoItem label="Nationality:" value="New Zealand" />
+      <InfoItem label="Employment Status:" value="Available" />
+      <InfoItem label="Phone:" value="+64 21 0248 8139" />
+      <InfoItem label="Address:" value="Auckland, New Zealand" />
+      <InfoItem label="Spoken Languages:" value="English" />
+    </div>
+    <WsImage />
+  </InfoContainer>
 )
 
 export default Cell2

--- a/src/components/box3/cellContent/WsImage.tsx
+++ b/src/components/box3/cellContent/WsImage.tsx
@@ -1,0 +1,10 @@
+import styled from 'styled-components'
+import backgroundImage from '../../../assets/warrick.jpg'
+
+const WsImage = styled.div`  
+    background-image: url(${backgroundImage});
+    background-size: cover;
+    background-position: center;
+  `
+
+  export default WsImage


### PR DESCRIPTION
This commit introduces a responsive layout to the Cell2 component using CSS grid. The layout adjusts based on the viewport width, ensuring a consistent and user-friendly experience across different device sizes.

Additionally, an image component (WsImage) has been added to the Cell2 component. The image is set as a background image and is styled to cover the entire div and center itself.

This change enhances the visual appeal and usability of the Cell2 component.